### PR TITLE
Higher-level API for querying data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ npm install nikel
 
 ### Example Usage:
 
+To use the higher-level APIs:
+```typescript
+import { Courses } from 'nikel';
+
+// Get courses for id=mat135
+const my_query = Courses.where({ id: 'mat135' })
+const my_courses = await my_query.get()     // An array of courses
+```
+
+To access the lower-level APIs directly:
 ```typescript
 // TypeScript (highly encouraged)
 import {Nikel} from 'nikel';

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ To use the higher-level APIs:
 import { Courses } from 'nikel';
 
 // Get courses for id=mat135
-const my_query = Courses.where({ id: 'mat135' })
-const my_courses = await my_query.get()     // An array of courses
+const my_courses = await Courses.where({ id: 'mat135' }).get()    // An array of courses
+
+// Or Using .then()
+Courses.where({ id: 'mat135' }).get()
+    .then(my_courses => console.log);
 ```
 
 To access the lower-level APIs directly:

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,15 @@ import axios, {AxiosInstance, AxiosResponse} from 'axios';
 import {Building, Course, Eval, Exam, Food, Parking, Response, Service, Textbook} from './types';
 
 export * from './types';
+export * from './models/Base';
+export * from './models/Buildings';
+export * from './models/Courses';
+export * from './models/Evals';
+export * from './models/Exams';
+export * from './models/Food';
+export * from './models/Parking';
+export * from './models/Services';
+export * from './models/Textbooks';
 
 /**
  * Nikel class

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -54,16 +54,12 @@ export default class Base {
         let request_query = request_params.formattedQuery();
         let request_url = `${this.endpoint}?${request_query}`
 
-        return await this.service.get(request_url);
-    }
-
-    json_result() {
-        return this.query.attributes;
+        let response = await this.service.get(request_url)
+        return response.data.response;
     }
 }
 
 function main(){
     let c = new Base();
-    c.where({code: { '$ew': 'C' }}).where({coordinates: {latitude: {'$gt': 43}}}).get().then(resp => console.log(JSON.stringify(resp.data.response, null, 2)))
+    c.where({code: { '$ew': 'C' }}).where({coordinates: {latitude: {'$gt': 43}}}).get().then(resp => console.log(JSON.stringify(resp, null, 2)))
 }
-main();

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -12,7 +12,7 @@ export default class Base {
      * @param query An object
      */
     where(query: Record<string, string | object | number | null>) {
-        this.query.where(query);
+        this.query.add_query(query);
         return this;
     }
 
@@ -38,7 +38,8 @@ export default class Base {
 
     /** Get the results. */
     get() {
-        this.endpoint_callback();
+        let request_params = this.query.compile();
+        console.log(request_params)
     }
 
     json_result() {
@@ -51,6 +52,8 @@ function main(){
     b.where({name: 'hi', more_key: {'$eq': 2}, nested: { layer_1: 'layer_1_val', layer_1_2: { '$lt': 5 }, nested_2: { layer_2: 'layer_2_val' } }}).where({name: {'$eq': 'another hi'}}).where({another_key: {'$gt': 5}, more_key: 6})
         .where({nested: {'$ne': 'nested_1_value', nested_2: { '$eq': 'nested_2_value', layer_2: { '$sw': 'some_prefix' } }}}).where({nested: {nested_2: {layer_2: 'new_layer_2_val_2'}}})
     b.offset(35).limit(50);
+
+    b.get();
     console.log('done', JSON.stringify(b.json_result(), null, 2))
 }
 main();

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -1,0 +1,18 @@
+import QueryObject from "./query/QueryObject";
+
+export default class Base {
+    /** Build out query requirements */
+    private query = new QueryObject();
+
+    /** Must override this from Base */
+    //private endpoint_callback = () => { throw new Error("Not implemented!") };
+    
+    /** Standard where query. Can be used to
+     * check equality, greater than, less than, etc.
+     * @param w_query An object 
+     */
+    where(w_query: Record<string, string | object>) {
+        this.query.where(w_query);
+        console.log(w_query);
+    }
+}

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -58,8 +58,3 @@ export default class Base {
         return response.data.response;
     }
 }
-
-function main(){
-    let c = new Base();
-    c.where({code: { '$ew': 'C' }}).where({coordinates: {latitude: {'$gt': 43}}}).get().then(resp => console.log(JSON.stringify(resp, null, 2)))
-}

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -5,14 +5,52 @@ export default class Base {
     private query = new QueryObject();
 
     /** Must override this from Base */
-    //private endpoint_callback = () => { throw new Error("Not implemented!") };
+    public endpoint_callback = () => { throw new Error("Not implemented!") };
     
     /** Standard where query. Can be used to
      * check equality, greater than, less than, etc.
-     * @param w_query An object 
+     * @param query An object
      */
-    where(w_query: Record<string, string | object>) {
-        this.query.where(w_query);
-        console.log(w_query);
+    where(query: Record<string, string | object | number | null>) {
+        this.query.where(query);
+        return this;
+    }
+
+    /** Set a limit of number of results to return. Defaults to 100.
+     * If multiple calls are made, only the last one will be used.
+     * @param new_limit The limit to set.
+     * @return this instance
+     * */
+    limit(new_limit: number) {
+        this.query.limit(new_limit);
+        return this;
+    }
+
+    /** Offset the query results. Defaults to 0.
+     * If multiple are provided, the last one will be used
+     * @param new_offset The offset to use.
+     * @return this instance
+     * */
+    offset(new_offset: number) {
+        this.query.offset(new_offset);
+        return this;
+    }
+
+    /** Get the results. */
+    get() {
+        this.endpoint_callback();
+    }
+
+    json_result() {
+        return this.query.attributes;
     }
 }
+
+function main(){
+    let b = new Base();
+    b.where({name: 'hi', more_key: {'$eq': 2}, nested: { layer_1: 'layer_1_val', layer_1_2: { '$lt': 5 }, nested_2: { layer_2: 'layer_2_val' } }}).where({name: {'$eq': 'another hi'}}).where({another_key: {'$gt': 5}, more_key: 6})
+        .where({nested: {'$ne': 'nested_1_value', nested_2: { '$eq': 'nested_2_value', layer_2: { '$sw': 'some_prefix' } }}}).where({nested: {nested_2: {layer_2: 'new_layer_2_val_2'}}})
+    b.offset(35).limit(50);
+    console.log('done', JSON.stringify(b.json_result(), null, 2))
+}
+main();

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -12,7 +12,7 @@ export default class Base {
      * check equality, greater than, less than, etc.
      * @param query An object
      */
-    where(query: Record<string, string | object | number | null>) {
+    where(query: Record<string, string | object | number | null>): Base {
         this.query.add_query(query);
         return this;
     }
@@ -22,7 +22,7 @@ export default class Base {
      * @param new_limit The limit to set.
      * @return this instance
      * */
-    public limit(new_limit: number) {
+    public limit(new_limit: number): Base {
         this.query.limit(new_limit);
         return this;
     }
@@ -32,14 +32,14 @@ export default class Base {
      * @param new_offset The offset to use.
      * @return this instance
      * */
-    public offset(new_offset: number) {
+    public offset(new_offset: number): Base {
         this.query.offset(new_offset);
         return this;
     }
 
     /** Get the results. */
     public get() {
-        let request_params = new RequestFromQueryObject(this.query.getQuery());
+        let request_params = new RequestFromQueryObject(this.query);
         let request_query = request_params.formattedQuery();
 
         console.log(request_query)
@@ -57,6 +57,9 @@ function main(){
     b.offset(35).limit(50);
 
     b.get();
-    console.log('done', JSON.stringify(b.json_result(), null, 2))
+
+    // let c = new Base();
+    // c.where({code: { '$ew': 'P' }}).where({coordinates: {latitude: {'$gt': 43}}}).get()
+    // console.log('done', JSON.stringify(b.json_result(), null, 2))
 }
 main();

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -1,4 +1,5 @@
 import QueryObject from "./query/QueryObject";
+import {RequestFromQueryObject} from "../utils/RequestFromQueryObject";
 
 export default class Base {
     /** Build out query requirements */
@@ -21,7 +22,7 @@ export default class Base {
      * @param new_limit The limit to set.
      * @return this instance
      * */
-    limit(new_limit: number) {
+    public limit(new_limit: number) {
         this.query.limit(new_limit);
         return this;
     }
@@ -31,15 +32,17 @@ export default class Base {
      * @param new_offset The offset to use.
      * @return this instance
      * */
-    offset(new_offset: number) {
+    public offset(new_offset: number) {
         this.query.offset(new_offset);
         return this;
     }
 
     /** Get the results. */
-    get() {
-        let request_params = this.query.compile();
-        console.log(request_params)
+    public get() {
+        let request_params = new RequestFromQueryObject(this.query.getQuery());
+        let request_query = request_params.formattedQuery();
+
+        console.log(request_query)
     }
 
     json_result() {

--- a/src/models/Base.ts
+++ b/src/models/Base.ts
@@ -1,12 +1,23 @@
 import QueryObject from "./query/QueryObject";
 import {RequestFromQueryObject} from "../utils/RequestFromQueryObject";
+import axios, {AxiosInstance} from "axios";
 
 export default class Base {
     /** Build out query requirements */
     private query = new QueryObject();
+    private service: AxiosInstance;
 
     /** Must override this from Base */
-    public endpoint_callback = () => { throw new Error("Not implemented!") };
+    public endpoint = 'OVERRIDE_ME';
+
+    constructor() {
+        this.service = axios.create({
+            baseURL: 'https://nikel.ml/api/',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+    }
     
     /** Standard where query. Can be used to
      * check equality, greater than, less than, etc.
@@ -38,11 +49,12 @@ export default class Base {
     }
 
     /** Get the results. */
-    public get() {
+    public async get() {
         let request_params = new RequestFromQueryObject(this.query);
         let request_query = request_params.formattedQuery();
+        let request_url = `${this.endpoint}?${request_query}`
 
-        console.log(request_query)
+        return await this.service.get(request_url);
     }
 
     json_result() {
@@ -51,15 +63,7 @@ export default class Base {
 }
 
 function main(){
-    let b = new Base();
-    b.where({name: 'hi', more_key: {'$eq': 2}, nested: { layer_1: 'layer_1_val', layer_1_2: { '$lt': 5 }, nested_2: { layer_2: 'layer_2_val' } }}).where({name: {'$eq': 'another hi'}}).where({another_key: {'$gt': 5}, more_key: 6})
-        .where({nested: {'$ne': 'nested_1_value', nested_2: { '$eq': 'nested_2_value', layer_2: { '$sw': 'some_prefix' } }}}).where({nested: {nested_2: {layer_2: 'new_layer_2_val_2'}}})
-    b.offset(35).limit(50);
-
-    b.get();
-
-    // let c = new Base();
-    // c.where({code: { '$ew': 'P' }}).where({coordinates: {latitude: {'$gt': 43}}}).get()
-    // console.log('done', JSON.stringify(b.json_result(), null, 2))
+    let c = new Base();
+    c.where({code: { '$ew': 'C' }}).where({coordinates: {latitude: {'$gt': 43}}}).get().then(resp => console.log(JSON.stringify(resp.data.response, null, 2)))
 }
 main();

--- a/src/models/Buildings.ts
+++ b/src/models/Buildings.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Buildings extends Base {
+    public endpoint = 'buildings';
+    constructor() { super(); }
+}

--- a/src/models/Courses.ts
+++ b/src/models/Courses.ts
@@ -4,12 +4,3 @@ export class Courses extends Base {
     public endpoint = 'courses';
     constructor() { super(); }
 }
-
-
-function main(){
-    let c = new Courses();
-    c.where({code: {'$sw': 'CSCA'}})
-    c.get().then(resp => console.log(JSON.stringify(resp, null, 2)))
-}
-
-main();

--- a/src/models/Courses.ts
+++ b/src/models/Courses.ts
@@ -1,0 +1,13 @@
+import Base from "./Base";
+
+class Courses extends Base {
+    
+}
+
+
+function main(){
+    let c = new Courses();
+    console.log(c);
+}
+
+main();

--- a/src/models/Courses.ts
+++ b/src/models/Courses.ts
@@ -1,15 +1,15 @@
 import Base from "./Base";
 
-class Courses extends Base {
-    public endpoint_callback = () => { throw new Error("Not implemented!") };
-
+export class Courses extends Base {
+    public endpoint = 'courses';
     constructor() { super(); }
 }
 
 
 function main(){
     let c = new Courses();
-    console.log(c);
+    c.where({code: {'$sw': 'CSCA'}})
+    c.get().then(resp => console.log(JSON.stringify(resp, null, 2)))
 }
 
 main();

--- a/src/models/Courses.ts
+++ b/src/models/Courses.ts
@@ -1,7 +1,9 @@
 import Base from "./Base";
 
 class Courses extends Base {
-    
+    public endpoint_callback = () => { throw new Error("Not implemented!") };
+
+    constructor() { super(); }
 }
 
 

--- a/src/models/Evals.ts
+++ b/src/models/Evals.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Evals extends Base {
+    public endpoint = 'evals';
+    constructor() { super(); }
+}

--- a/src/models/Exams.ts
+++ b/src/models/Exams.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Exams extends Base {
+    public endpoint = 'exams';
+    constructor() { super(); }
+}

--- a/src/models/Food.ts
+++ b/src/models/Food.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Foods extends Base {
+    public endpoint = 'food';
+    constructor() { super(); }
+}

--- a/src/models/Parking.ts
+++ b/src/models/Parking.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Parkings extends Base {
+    public endpoint = 'parking';
+    constructor() { super(); }
+}

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -1,6 +1,6 @@
 # Models
 This section contains information on each of the models provided by the Nikel API. All models inherit
-from `Base`, and only specify information that is unique to them. Currently, that information is
+from `Base`, and only specify information that is unique to them. Currently, that information 
 tells the `Axios` service where to send queries.
 
 ## Usage
@@ -30,7 +30,7 @@ import { Courses } from nikel;
 Courses.where({ id: 'CSCA08' }).get();
 
 // More verbously
-Courses.where({ id: { '$eq': 'CSCA08' } }).get();
+Courses.where({ id: { $eq: 'CSCA08' } }).get();
 ```
 (b) To access a nested field
 ```typescript
@@ -46,7 +46,7 @@ import { Foods } from nikel;
 let my_food = Foods.where({ campus: 'St. George' });
 
 if(its_my_birthday()) {
-    my_food.where({ coordinates: { longitude: { '$lt': 50 } } });
+    my_food.where({ coordinates: { longitude: { $lt: 50 } } });
 }
 
 my_food.get();   // All food places at St. George with longitude less than 50
@@ -54,16 +54,15 @@ my_food.get();   // All food places at St. George with longitude less than 50
 
 (d) Combining various operations
 ```typescript
-import { Courses } from nikel;
+import { Buildings } from nikel;
 
-let my_courses = Courses.where({
-    id: { '$sw': 'CSC' },
-    level: '200/B',
-    name: { '$ew': 'II' }
-})
-.where({
-    recommended_preparation: null,
-    campus: 'Scarborough',
-    apsc_electives: { '$eq': null } 
+let my_courses = Buildings.where({
+    id: { $sw: '13' },
+    code: 'NR',
+    name: { $ew: 'II' },
+    coordinates: {
+        latitude: { $gt: 30 },
+        longitude: -79.40078
+    }
 });
 ```

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -24,7 +24,7 @@ They can be as deeply nested and compounded as desired.
 
 (a) To get a course by code:
 ```typescript
-import { Courses } from Nikel;
+import { Courses } from nikel;
 
 // Course for id='CSCA08'
 Courses.where({ id: 'CSCA08' }).get();
@@ -34,14 +34,14 @@ Courses.where({ id: { '$eq': 'CSCA08' } }).get();
 ```
 (b) To access a nested field
 ```typescript
-import { Buildings } from Nikel;
+import { Buildings } from nikel;
 
 Buildings.where({ address: { postal: 'M5S 1A1' } }).get();
 ```
 
 (c) Change query based on a condition
 ```typescript
-import { Foods } from Nikel;
+import { Foods } from nikel;
 
 let my_food = Foods.where({ campus: 'St. George' });
 
@@ -54,7 +54,7 @@ my_food.get();   // All food places at St. George with longitude less than 50
 
 (d) Combining various operations
 ```typescript
-import { Courses } from Nikel;
+import { Courses } from nikel;
 
 let my_courses = Courses.where({
     id: { '$sw': 'CSC' },

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -1,0 +1,69 @@
+# Models
+This section contains information on each of the models provided by the Nikel API. All models inherit
+from `Base`, and only specify information that is unique to them. Currently, that information is
+tells the `Axios` service where to send queries.
+
+## Usage
+All queries use a syntax similar to the MongoDB query selectors. The following operations are 
+supported:
+1. `$eq` -- Equality
+2. `$ne` -- Inequality
+3. `$lt` -- Less than
+4. `$lte` -- Less than or equal to
+5. `$gt` -- Greater than
+6. `$gte` -- Greater than or equal to
+7. `$sw` -- Starts with
+8. `$ew` -- Ends with
+
+When an operation is not provided, the _equality_ operator is assumed.
+
+To query with any of the above, simply pass in a hash that uses them via a `where()` clause. 
+They can be as deeply nested and compounded as desired.
+
+### Examples
+
+(a) To get a course by code:
+```typescript
+import { Courses } from Nikel;
+
+// Course for id='CSCA08'
+Courses.where({ id: 'CSCA08' }).get();
+
+// More verbously
+Courses.where({ id: { '$eq': 'CSCA08' } }).get();
+```
+(b) To access a nested field
+```typescript
+import { Buildings } from Nikel;
+
+Buildings.where({ address: { postal: 'M5S 1A1' } }).get();
+```
+
+(c) Change query based on a condition
+```typescript
+import { Foods } from Nikel;
+
+let my_food = Foods.where({ campus: 'St. George' });
+
+if(its_my_birthday()) {
+    my_food.where({ coordinates: { longitude: { '$lt': 50 } } });
+}
+
+my_food.get();   // All food places at St. George with longitude less than 50
+```
+
+(d) Combining various operations
+```typescript
+import { Courses } from Nikel;
+
+let my_courses = Courses.where({
+    id: { '$sw': 'CSC' },
+    level: '200/B',
+    name: { '$ew': 'II' }
+})
+.where({
+    recommended_preparation: null,
+    campus: 'Scarborough',
+    apsc_electives: { '$eq': null } 
+});
+```

--- a/src/models/Services.ts
+++ b/src/models/Services.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Services extends Base {
+    public endpoint = 'services';
+    constructor() { super(); }
+}

--- a/src/models/Textbooks.ts
+++ b/src/models/Textbooks.ts
@@ -1,0 +1,6 @@
+import Base from "./Base";
+
+export class Textbooks extends Base {
+    public endpoint = 'textbooks';
+    constructor() { super(); }
+}

--- a/src/models/query/Exceptions.ts
+++ b/src/models/query/Exceptions.ts
@@ -2,3 +2,7 @@ export default class QueryError extends Error {
     constructor(message: string) { super(message) }
 }
 
+export class InvalidQueryError extends QueryError {
+    constructor(message: string) { super(message); }
+}
+

--- a/src/models/query/Exceptions.ts
+++ b/src/models/query/Exceptions.ts
@@ -1,0 +1,4 @@
+export default class QueryError extends Error {
+    constructor(message: string) { super(message) }
+}
+

--- a/src/models/query/QueryObject.ts
+++ b/src/models/query/QueryObject.ts
@@ -4,7 +4,7 @@ import QueryError from './Exceptions';
 export default class QueryObject {
     /** Keep track of what user wants to query for,
      * where each attribute can have a different properties (equality, greater than, etc.)
-     * Each key will have the following value:
+     * Each key will have the following $properties value:
      * {
      *      equality: string[],
      *      inequality: string[],
@@ -16,7 +16,18 @@ export default class QueryObject {
      *      ends_with: string
      * }
      */
-    private attributes: any = { };
+    public attributes: any = { };
+
+    private static SYMBOL_TO_TYPE_MAPPING = {
+        '$eq': 'equality',
+        '$ne': 'inequality',
+        '$lt': 'less_than',
+        '$lte': 'less_than_equal_to',
+        '$gt': 'greater_than',
+        '$gte': 'greater_than_equal_to',
+        '$sw': 'starts_with',
+        '$ew': 'ends_with'
+    }
 
     /** Keep track of meta-data such as limit,  */
     //private meta: any = { };
@@ -33,7 +44,7 @@ export default class QueryObject {
                     break;
             
                 case 'object':
-                    this._handleObjectUpdate(attribute, value);
+                    this._handleObjectUpdate(attribute, value, this.attributes);
                     break;
 
                 default:
@@ -46,69 +57,99 @@ export default class QueryObject {
     /** For when a single value is assigned to an attribute
      * e.g. Base.where({name: 'some_name'})
      */
-    private _handleAtomicUpdate(key: string, val: string | number, update_type: string, parent: any) {
+    private _handleAtomicUpdate(key: string, val: string | number, update_type: string, attributes_level: any) {
         // console.log('atomic update', key, val, update_type, parent);
-
-        // Two cases: This attribute is already defined, or we need to create space for it
-        if(!parent[key]) {
-            // Initialize
-            this._initializeAttributeValue(parent);
+        if(val === 'new_layer_2_val') {
+            console.log('here')
         }
-        console.log({parent: parent, key: key, val: val})
-        parent[update_type].push(val);
+        // Two cases: This attribute is already defined, or we need to create space for it
+        if(!attributes_level[key]) {
+            // Initialize
+            attributes_level[key] = { }
+            this._initializeAttributeValue(attributes_level[key]);
+        }
+        else if(!attributes_level[key]['$properties']) {
+            this._initializeAttributeValue(attributes_level[key]);
+        }
+       // console.log({parent: parent, key: key, val: val})
+        attributes_level[key]['$properties'][update_type].push(val);
 
-        console.log('new attributes', this.attributes);
     }
 
     /** For when a more complicated object is assigned to an attribute
      * e.g. Base.where({name: {$ne: 'name_to_avoid'}})
      */
-    private _handleObjectUpdate(key: string, val: any) {
-        for(const update_type in val) {
-            switch (update_type) {
-                case '$eq':
-                    this._handleAtomicUpdate(update_type, val[update_type], 'equality', val);
-                    break;
-                case '$ne':
-                    break;
-                case '$lt':
-                    break;
-                case '$lte':
-                    break;
-                case '$gt':
-                    break;
-                case '$gte':
-                    break;
-                case '$sw':
-                    break;
-                case '$ew':
-                    break;
-                default:
-                    // This is some other field that we need to narrow down to
-                    this._handleObjectUpdate(update_type, val[update_type]);
-            }
+    private _handleObjectUpdate(key: string, val: any, attribute_level: any) {
+        if(typeof(val) !== 'object') {
+            if(!attribute_level[key]) { attribute_level[key] = { } }
+            this._handleAtomicUpdate(key, val, 'equality', attribute_level);
+            return;
         }
-        console.log(key, val);
+
+        for(const update_type in val) {
+            let update_types_mapping = QueryObject.SYMBOL_TO_TYPE_MAPPING;
+
+            // @ts-ignore -- Figure out what's happening here lol
+            let res = update_types_mapping[update_type] as any;
+
+            if(res) {
+                this._handleAtomicUpdate(key, val[update_type], res, attribute_level);
+            } else {
+                if(!attribute_level[key]) {
+                    attribute_level[key] = { };
+
+                    this._initializeAttributeValue(attribute_level[key])
+                }
+                this._handleObjectUpdate(update_type, val[update_type], attribute_level[key]);
+            }
+            // switch (update_type) {
+            //     case '$eq':
+            //         this._handleAtomicUpdate(key, val[update_type], 'equality', attribute_level);
+            //         break;
+            //     case '$ne':
+            //
+            //         break;
+            //     case '$lt':
+            //         break;
+            //     case '$lte':
+            //         break;
+            //     case '$gt':
+            //         break;
+            //     case '$gte':
+            //         break;
+            //     case '$sw':
+            //         break;
+            //     case '$ew':
+            //         break;
+            //     default:
+            //         // This is some other field that we need to narrow down to
+            //         this._handleObjectUpdate(update_type, val[update_type], attribute_level[key]);
+            // }
+        }
+        //console.log(key, val);
     }
 
     private _initializeAttributeValue(attribute: any) {
         console.log("creating new attributes for: ", attribute)
-        attribute['equality'] = [];
-        attribute['inequality'] = [];
+        attribute['$properties'] = { }
+        attribute['$properties']['equality'] = [];
+        attribute['$properties']['inequality'] = [];
         
-        attribute['less_than'] = [];
-        attribute['less_than_equal_to'] = [];
-        attribute['greater_than'] = [];
-        attribute['greater_than_equal_to'] = [];
+        attribute['$properties']['less_than'] = [];
+        attribute['$properties']['less_than_equal_to'] = [];
+        attribute['$properties']['greater_than'] = [];
+        attribute['$properties']['greater_than_equal_to'] = [];
 
-        attribute['starts_with'] = '';
-        attribute['ends_with'] = '';
+        attribute['$properties']['starts_with'] = '';
+        attribute['$properties']['ends_with'] = '';
     }
 }
 
 function main() {
     let q = new QueryObject();
-    q.where({name: 'hi'}).where({name: 'bye'})
+    q.where({name: 'hi', more_key: {'$eq': 2}, nested: { layer_1: 'layer_1_val', layer_1_2: 'layer_1_2_val', nested_2: { layer_2: 'layer_2_val' } }}).where({name: {'$eq': 'another hi'}}).where({another_key: 5, more_key: 6})
+        .where({nested: {'$eq': 'nested_1_value', nested_2: { '$eq': 'nested_2_value' }}}).where({nested: {nested_2: {layer_2: 'new_layer_2_val'}}})
+    console.log('done', JSON.stringify(q.attributes, null, 2))
 }
 
 main();

--- a/src/models/query/QueryObject.ts
+++ b/src/models/query/QueryObject.ts
@@ -1,0 +1,114 @@
+import QueryError from './Exceptions';
+
+/** A class to represent all the queries that can be made. */
+export default class QueryObject {
+    /** Keep track of what user wants to query for,
+     * where each attribute can have a different properties (equality, greater than, etc.)
+     * Each key will have the following value:
+     * {
+     *      equality: string[],
+     *      inequality: string[],
+     *      less_than: (number | string)[],
+     *      less_than_equal_to: (number | string)[],
+     *      greater_than: (number | string)[],
+     *      greater_than_equal_to: (number | string)[],
+     *      starts_with: string,
+     *      ends_with: string
+     * }
+     */
+    private attributes: any = { };
+
+    /** Keep track of meta-data such as limit,  */
+    //private meta: any = { };
+
+    where(query: any) {
+        for(const attribute in query) {
+            let value = query[attribute];
+            let val_type = typeof(value);
+
+            switch (val_type) {
+                case 'string':
+                case 'number':
+                    this._handleAtomicUpdate(attribute, value, "equality", this.attributes);
+                    break;
+            
+                case 'object':
+                    this._handleObjectUpdate(attribute, value);
+                    break;
+
+                default:
+                    throw new QueryError('All values must be either a string, a number, or an object.');
+            }
+        }
+        return this;
+    }
+
+    /** For when a single value is assigned to an attribute
+     * e.g. Base.where({name: 'some_name'})
+     */
+    private _handleAtomicUpdate(key: string, val: string | number, update_type: string, parent: any) {
+        // console.log('atomic update', key, val, update_type, parent);
+
+        // Two cases: This attribute is already defined, or we need to create space for it
+        if(!parent[key]) {
+            // Initialize
+            this._initializeAttributeValue(parent);
+        }
+        console.log({parent: parent, key: key, val: val})
+        parent[update_type].push(val);
+
+        console.log('new attributes', this.attributes);
+    }
+
+    /** For when a more complicated object is assigned to an attribute
+     * e.g. Base.where({name: {$ne: 'name_to_avoid'}})
+     */
+    private _handleObjectUpdate(key: string, val: any) {
+        for(const update_type in val) {
+            switch (update_type) {
+                case '$eq':
+                    this._handleAtomicUpdate(update_type, val[update_type], 'equality', val);
+                    break;
+                case '$ne':
+                    break;
+                case '$lt':
+                    break;
+                case '$lte':
+                    break;
+                case '$gt':
+                    break;
+                case '$gte':
+                    break;
+                case '$sw':
+                    break;
+                case '$ew':
+                    break;
+                default:
+                    // This is some other field that we need to narrow down to
+                    this._handleObjectUpdate(update_type, val[update_type]);
+            }
+        }
+        console.log(key, val);
+    }
+
+    private _initializeAttributeValue(attribute: any) {
+        console.log("creating new attributes for: ", attribute)
+        attribute['equality'] = [];
+        attribute['inequality'] = [];
+        
+        attribute['less_than'] = [];
+        attribute['less_than_equal_to'] = [];
+        attribute['greater_than'] = [];
+        attribute['greater_than_equal_to'] = [];
+
+        attribute['starts_with'] = '';
+        attribute['ends_with'] = '';
+    }
+}
+
+function main() {
+    let q = new QueryObject();
+    q.where({name: 'hi'}).where({name: 'bye'})
+}
+
+main();

--- a/src/models/query/QueryObject.ts
+++ b/src/models/query/QueryObject.ts
@@ -120,7 +120,7 @@ export default class QueryObject {
      */
     private _handleObjectUpdate(key: string, val: any, attribute_level: any) {
         // If we're dealing with a single value
-        if(typeof(val) !== 'object') {
+        if(typeof(val) !== 'object' || val == null) {
             // Base Case: We're no longer working with objects
             // Make sure we have allocated room for this attribute
             if(!attribute_level[key]) { attribute_level[key] = { } }

--- a/src/models/query/QueryObject.ts
+++ b/src/models/query/QueryObject.ts
@@ -35,7 +35,7 @@ export default class QueryObject {
      * @param query The query to parse
      * @return this instance
      * */
-    add_query(query: any) {
+    add_query(query: any): QueryObject {
         for(const attribute in query) {
             let value = query[attribute];
             let val_type = typeof(value);
@@ -77,20 +77,20 @@ export default class QueryObject {
         this.meta.offset = new_offset;
     }
 
-    /** Compile and return this query object into something
-     * that can be directly passed into a request body
-     * @return
-     * */
-    compile() {
-
-    }
-
     /** Get an object representing all the Queries made.
      * @return An object with all the queries
      * */
     public getQuery() {
         // Deep clone
         return JSON.parse(JSON.stringify(this.attributes));
+    }
+
+    /** Additional attributes that identify this
+     * query. E.g. the limit, offset, etc.
+     * @return Additional properties for this query
+     * */
+    public getMeta() {
+        return JSON.parse(JSON.stringify(this.meta));
     }
 
     /** For when a single value is assigned to an attribute

--- a/src/utils/RequestFromQueryObject.ts
+++ b/src/utils/RequestFromQueryObject.ts
@@ -60,6 +60,12 @@ export class RequestFromQueryObject {
         return encodeURI(url_builder);
     }
 
+    /** For a given attribute (e.g. name, address, code, etc.) generate a query string that
+     * represents it
+     * @param sub_query The object where this attribute is located
+     * @param key The key of the sub_query that identifies this attribute
+     * @param parent_key What is the key of the parent, optional.
+     * */
     private getUrlFromAttribute(sub_query: any, key: string, parent_key?: string) {
         let url = '';
         let url_key = parent_key ? `${parent_key}.${key}` : key
@@ -76,6 +82,9 @@ export class RequestFromQueryObject {
 
     /** Given a properties hash, return a string query
      * that represents it
+     * @param properties A $properties hash
+     * @param url_key A string that represents the attribute,
+     * for example 'coordinate.latitude', 'address.postal_code', 'name', etc.
      * */
     private getUrlParamsFromPropertiesHash(properties: any, url_key: string) {
         let url = '';

--- a/src/utils/RequestFromQueryObject.ts
+++ b/src/utils/RequestFromQueryObject.ts
@@ -3,9 +3,68 @@ import QueryObject from "../models/query/QueryObject";
 export class RequestFromQueryObject {
     query_object: QueryObject;
 
+    public static SYMBOL_TO_URL_MAPPING: any = {
+        '$eq': '=',
+        '$ne': '!',
+        '$lt': '<',
+        '$lte': '<=',
+        '$gt': '>',
+        '$gte': '>=',
+        '$sw': '(',
+        '$ew': ')'
+    }
+
     constructor(query: QueryObject) { this.query_object = query }
 
+    /** Returns a string containing a query string that
+     * can be used directly in a URL
+     * @return A query string that can be used in a URL.
+     * */
     public formattedQuery() {
-        return []
+        let root_query = this.query_object.getQuery();
+        return this.getUrlFromQuery(root_query);
+    }
+
+    /** Generate a query string URL
+     * from a QueryObject. This does most of the work.
+     * @param query The QueryObject to convert.
+     * */
+    private getUrlFromQuery(query: any) {
+        let url_builder = '';
+
+        for(const attribute in query) {
+            url_builder += this.getUrlFromAttribute(query[attribute], attribute)
+        }
+        // Technically don't need to remove trailing &, it just looks nicer that way
+        if(url_builder.endsWith('&')) { url_builder = url_builder.slice(0, -1) }
+        return encodeURI(url_builder);
+    }
+
+    private getUrlFromAttribute(sub_query: any, key: string, parent_key?: string) {
+        let url = '';
+        let url_key = parent_key ? `${parent_key}.${key}` : key
+
+        for(const attribute in sub_query) {
+            if(attribute === '$properties') {
+                url += this.getUrlParamsFromPropertiesHash(sub_query[attribute], url_key)
+            } else {
+                url += this.getUrlFromAttribute(sub_query[attribute], attribute, url_key);
+            }
+        }
+        return url;
+    }
+
+    /** Given a properties hash, return a string query
+     * that represents it
+     * */
+    private getUrlParamsFromPropertiesHash(properties: any, url_key: string) {
+        let url = '';
+        for(const p_key in properties) {
+            let property_array = properties[p_key] as Array<string>;
+            let operator = RequestFromQueryObject.SYMBOL_TO_URL_MAPPING[p_key];
+
+            property_array.forEach((value) => { url += `${url_key}=${operator}${value}&` })
+        }
+        return url;
     }
 }

--- a/src/utils/RequestFromQueryObject.ts
+++ b/src/utils/RequestFromQueryObject.ts
@@ -21,9 +21,29 @@ export class RequestFromQueryObject {
      * @return A query string that can be used in a URL.
      * */
     public formattedQuery() {
+        // All the fields that user wants to query
         let root_query = this.query_object.getQuery();
-        return this.getUrlFromQuery(root_query);
+
+        // All the additional meta data, such as limit & offset
+        let meta_query = this.query_object.getMeta();
+
+        let query_uri = this.getUrlFromQuery(root_query)
+        let meta_uri = this.getURLFromMetaQuery(meta_query);
+        return query_uri + '&' + meta_uri;
     }
+
+    /** Generate a query string to represent meta data
+     * @param query The query containing meta data
+     * */
+    private getURLFromMetaQuery(query: any) {
+        let url = '';
+        for(const key in query) {
+            url += `${key}=${query[key]}&`;
+        }
+        if(url.endsWith('&')) { url = url.slice(0, -1) }
+        return url;
+    }
+
 
     /** Generate a query string URL
      * from a QueryObject. This does most of the work.

--- a/src/utils/RequestFromQueryObject.ts
+++ b/src/utils/RequestFromQueryObject.ts
@@ -1,0 +1,11 @@
+import QueryObject from "../models/query/QueryObject";
+
+export class RequestFromQueryObject {
+    query_object: QueryObject;
+
+    constructor(query: QueryObject) { this.query_object = query }
+
+    public formattedQuery() {
+        return []
+    }
+}


### PR DESCRIPTION
This PR provides the ability to query data from all existing APIs via a MongoDB-like syntax. All query classes inherit from `Base`, and with the help of a `QueryBuilder` and some other helper methods, a user can do queries like:

```typescript
import { Courses } from nikel;

// Course for id='CSCA08'
Courses.where({ id: 'CSCA08' }).get();

// More verbously
Courses.where({ id: { '$eq': 'CSCA08' } }).get();
```

The `QueryBuilder` allows for stacking as many queries as desired, with currently no limit on a depth. These queries can therefore get arbitrarily complex, although this new format should help organize them better.

Checkout the `README.md` under `src/models/` for more details and usage examples. 